### PR TITLE
Remove softmax activation from last layer.

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,6 +52,9 @@ def viz_grad_cam(model, image, interpolant=0.5):
     # Sanity Check
     assert 0 < interpolant < 1, "Heatmap Interpolation Must Be Between 0 - 1"
 
+    # Remove softmax activation from the last layer of MobileNetV2
+    model.layers[ -1 ].activation = None
+
     last_conv_layer = next(
         x for x in model.layers[::-1] if isinstance(x, tf.keras.layers.Conv2D)
     )


### PR DESCRIPTION
To use GRAD-CAM for image classification models, we need to remove the softmax activation from the last layer of MobileNet. The line from the [paper](https://arxiv.org/abs/1610.02391), suggests,

> ... As shown in Fig. 2, in order to obtain the class-discriminative localization map ... of width u
> and height v for any class c, we first compute the gradient of the score for class c, yc **(before the softmax)**, with respect to
> feature map activations Ak of a convolutional layer ...

I have added a line to `main.py` to remove the softmax activation.

```
model.layers[ -1 ].activation = None
```

